### PR TITLE
TS2741: Property 'translate' is missing in type '{ ref: RefObject<HTM…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,3 +63,6 @@
 
 
 ### Unreleased
+**Release 0.1.18** - 2021-08-02
+- TS2741: Property 'translate' is missing in type '{ ref: RefObject<HTMLFormElement>; 🐛 [Issue  #143](https://github.com/joegasewicz/react-bare-forms/issues/#143)
+

--- a/src/elements.tsx
+++ b/src/elements.tsx
@@ -105,6 +105,7 @@ export interface IRadioField extends IField<HTMLInputElement> {
 
 export interface IFileField extends IField<HTMLInputElement> {
     ref: React.RefObject<HTMLFormElement>;
+    translate?: "yes" | "no" | undefined;
 }
 
 export type TypeSelectCssSizeName = |"sm"|"default"|"lg";

--- a/src/field_classes/_FileField.tsx
+++ b/src/field_classes/_FileField.tsx
@@ -45,6 +45,7 @@ export class FileField<T extends IField<HTMLInputElement>> extends AbstractField
     public getField() {
         return () => <>{<input
             {...this.props}
+            translate={this.props.translate || undefined}
             ref={(this.props as any).ref}
             type={this.type}
             onChange={this.handleOnChange}


### PR DESCRIPTION
…LFormElement>; Fixes #143